### PR TITLE
ci: downgrade backup workflow Node version to 22 to fix keep-alive to…

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Install Dependencies


### PR DESCRIPTION
…ken fetch issue